### PR TITLE
Add forecast data to end point

### DIFF
--- a/recommender-back/src/routes.py
+++ b/recommender-back/src/routes.py
@@ -1,7 +1,6 @@
 from app import app
 from flask import jsonify
-import apis.weather as weather
-import apis.poi as poi
+from apis import weather, poi
 
 
 @app.route('/', methods=['GET'])
@@ -29,7 +28,7 @@ def get_weather():
         The weather data if errors have not occurred.
 
     """
-    return weather.get_weather()
+    return weather.get_full_weather_info()
 
 @app.route('/api/poi', methods=['GET'])
 def get_poi_data():

--- a/recommender-back/src/tests/apis/weather_test.py
+++ b/recommender-back/src/tests/apis/weather_test.py
@@ -9,7 +9,7 @@ class WeatherTest(unittest.TestCase):
         self.client = app.test_client()
 
     def test_get_weather_error(self):
-        with mock.patch('apis.weather.query_handler', side_effect=Exception('Test exception')):
+        with mock.patch('apis.weather._current_query_handler', side_effect=Exception('Test exception')):
             error_response = self.client.get('/api/weather')
             error_data = error_response.get_json()
             self.assertEqual(error_response.status_code, 500)

--- a/recommender-front/src/components/WeatherComponent.jsx
+++ b/recommender-front/src/components/WeatherComponent.jsx
@@ -12,8 +12,8 @@ function WeatherComponent() {
       .then((res) => res.json())
       .then((responseData) => {
         setData({
-          airtemperature: responseData.airtemperature,
-          airquality: responseData.airquality,
+          airtemperature: responseData.current['air temperature'],
+          airquality: responseData.current['air quality'],
         });
       })
       .catch((error) => {

--- a/recommender-front/src/components/WeatherComponent.test.jsx
+++ b/recommender-front/src/components/WeatherComponent.test.jsx
@@ -6,7 +6,14 @@ import { setupServer } from 'msw/node';
 import WeatherComponent from './WeatherComponent';
 
 const server = setupServer(
-  rest.get('*/api/weather', (req, res, ctx) => res(ctx.json({ airtemperature: 22, airquality: 35 }))),
+  rest.get('*/api/weather', (req, res, ctx) => res(
+    ctx.json({
+      current: {
+        'air temperature': '22',
+        'air quality': '35',
+      },
+    }),
+  )),
 );
 
 beforeAll(() => server.listen());


### PR DESCRIPTION
Adds forecast data to end point /api/weather

json format values:

"current" -> contains current weather info
"forecast" -> contains forecast weather info

Could use some refactoring. Also, feel free to make changes as necessary.