### PR TITLE
Changed map to be responsive

### DIFF
--- a/recommender-front/src/components/MapComponent.jsx
+++ b/recommender-front/src/components/MapComponent.jsx
@@ -24,7 +24,7 @@ function MapComponent() {
 
   console.log(poiData);
   return (
-    <MapContainer center={position} zoom={16} scrollWheelZoom={false} style={{ height: '500px', width: '500px' }}>
+    <MapContainer center={position} zoom={14} scrollWheelZoom={false} style={{ height: '85vh', minHeight: '100px' }}>
       <TileLayer
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'


### PR DESCRIPTION
Closes #69 

- Used these style settings to make map responsive `height: '85vh', minHeight: '100px`
- Tested map with Chrome tools mobile viewports