### PR TITLE
quick fix for gunicorn

### DIFF
--- a/recommender-back/gunicorn_config.py
+++ b/recommender-back/gunicorn_config.py
@@ -1,6 +1,6 @@
 import multiprocessing
 
-BIND = "0.0.0.0:8000"
+BIND = "0.0.0.0:5000"
 workers = multiprocessing.cpu_count() * 2 + 1
 WORKER_CLASS = "gevent"
 PRELOAD_APP = True


### PR DESCRIPTION
fixes #223 
Gunicorn launched backend in port 8000, but production Nginx was configured to search for port 5000, hence backend stopped working.