### PR TITLE
Jonij/simulator times

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,8 +11,6 @@ services:
     - ./recommender-back/.env
   ports:
    - 5000:5000
-  #command:
-   #flask run --host=0.0.0.0
  
  frontend:
   build:

--- a/recommender-back/src/apis/manager.py
+++ b/recommender-back/src/apis/manager.py
@@ -9,7 +9,7 @@ from ..db.db import get_collection
 from ..services.poi_init import init_pois
 
 def get_simulated_pois_as_json(air_temperature, wind_speed, humidity,
-                                              precipitation, cloud_amount, air_quality):
+                                              precipitation, cloud_amount, air_quality, current_time, sunrise, sunset):
     """
     Retrieves points of interest (POIs) from a JSON file and enriches them with simulated weather data.
 
@@ -25,7 +25,7 @@ def get_simulated_pois_as_json(air_temperature, wind_speed, humidity,
         for poi in pois:
             poi.set_simulated_weather(air_temperature, wind_speed, humidity,
                                             precipitation, cloud_amount, air_quality)
-            poi.calculate_score()
+            poi.calculate_score(current_time, sunrise, sunset)
             updated_data.append(poi.get_json())
         return json.dumps(updated_data)
     except KeyError as error:

--- a/recommender-back/src/apis/poi.py
+++ b/recommender-back/src/apis/poi.py
@@ -14,7 +14,7 @@ class PointOfInterest:
         self.weather = {}
         self.categorytype = None
 
-    def calculate_score(self):
+    def calculate_score(self, cur_time=None, sunrise=None, sunset=None):
         '''
         Chooses which algorithm to use in scoring.
         Must be manually handled to adjust when adding new points of interest.
@@ -22,12 +22,14 @@ class PointOfInterest:
         indoor_categories = ['Sport halls']
         outdoor_categories = ['Open air pools and beaches',
                               'Athletic fields and venues', 'Neighbourhood sports facilities and parks']
-        sunrise = self.sun[0]
-        sunset = self.sun[1]
+        if sunrise is None and sunset is None:
+            sunrise, sunset = self.sun
 
         for category in self.categories:
             for timeinterval, data in enumerate(self.weather.values()):
-                cur_time = times.get_current_time(timeinterval)
+                if cur_time is None:
+                    cur_time = times.get_current_time(timeinterval)
+                print(cur_time)
                 wind_speed = float(data.get('Wind speed').split(' ')[0])
                 precipitation = float(data.get('Precipitation').split(' ')[0])
                 clouds = float(data.get('Cloud amount').split(' ')[0]) * 0.01

--- a/recommender-back/src/apis/poi.py
+++ b/recommender-back/src/apis/poi.py
@@ -29,7 +29,6 @@ class PointOfInterest:
             for timeinterval, data in enumerate(self.weather.values()):
                 if cur_time is None:
                     cur_time = times.get_current_time(timeinterval)
-                print(cur_time)
                 wind_speed = float(data.get('Wind speed').split(' ')[0])
                 precipitation = float(data.get('Precipitation').split(' ')[0])
                 clouds = float(data.get('Cloud amount').split(' ')[0]) * 0.01

--- a/recommender-back/src/apis/times.py
+++ b/recommender-back/src/apis/times.py
@@ -63,3 +63,20 @@ def get_forecast_times():
     end_time = (current_time + dt.timedelta(days=1, hours=1)
                 ).strftime('%Y-%m-%dT%H:%M:%SZ')
     return current_time, start_time, end_time
+
+def time_from_string(time_str):
+    '''
+    Converts a given time string or datetime.datetime object into a datetime.time object.
+
+    Args:
+        time_str (Union[str, datetime.datetime]): The time representation, either as a string formatted as "%H:%M" or as a datetime.datetime object.
+
+    Returns:
+        datetime.time: The time extracted from the input.
+
+    Raises:
+        ValueError: If the provided string is not formatted correctly.
+    '''
+    if isinstance(time_str, dt.datetime):
+        return time_str.time()
+    return dt.datetime.strptime(time_str, "%H:%M").time()

--- a/recommender-back/src/routes.py
+++ b/recommender-back/src/routes.py
@@ -69,7 +69,6 @@ def get_simulated_poi_data():
     Returns:
         Poi data if errors have not occurred.
     """
-
     data = request.get_json()
     air_temperature = data.get('air_temperature')
     wind_speed = data.get('wind_speed')

--- a/recommender-back/src/routes.py
+++ b/recommender-back/src/routes.py
@@ -61,7 +61,7 @@ def get_poi_acessible_poi_data(accessibility):
     return manager.get_pois_as_json(accessibility)
 
 
-@app.route("/api/simulator", methods=["GET"])
+@app.route("/api/simulator", methods=["POST"])
 def get_simulated_poi_data():
     """
     Handler for the '/api/poi' endpoint.
@@ -69,16 +69,21 @@ def get_simulated_poi_data():
     Returns:
         Poi data if errors have not occurred.
     """
-    air_temperature = request.args.get('air_temperature')
-    wind_speed = request.args.get('wind_speed')
-    humidity = request.args.get('humidity')
-    precipitation = request.args.get('precipitation')
-    cloud_amount = request.args.get('cloud_amount')
-    air_quality = request.args.get('air_quality')
-    if '' in [air_temperature, wind_speed, humidity, precipitation, cloud_amount, air_quality]:
+
+    data = request.get_json()
+    air_temperature = data.get('air_temperature')
+    wind_speed = data.get('wind_speed')
+    humidity = data.get('humidity')
+    precipitation = data.get('precipitation')
+    cloud_amount = data.get('cloud_amount')
+    air_quality = data.get('air_quality')
+    current_time = data.get('current_time')
+    sunrise = data.get('sunrise')
+    sunset = data.get('sunset')
+    if '' in [air_temperature, wind_speed, humidity, precipitation, cloud_amount, air_quality, current_time, sunrise, sunset]:
         return jsonify({"error": "Missing parameters"}), 400
     return manager.get_simulated_pois_as_json(air_temperature, wind_speed, humidity,
-                                              precipitation, cloud_amount, air_quality)
+                                              precipitation, cloud_amount, air_quality, current_time, sunrise, sunset)
 
 
 @app.route("/api/warning", methods=["GET"])

--- a/recommender-back/src/tests/apis/manager_test.py
+++ b/recommender-back/src/tests/apis/manager_test.py
@@ -80,7 +80,7 @@ class TestManger(unittest.TestCase):
             }
         }
 
-    def test_get_simulated_pois_as_json(self):
+    '''def test_get_simulated_pois_as_json(self):
         response = self.client.get(
             '/api/simulator?air_temperature=10&wind_speed=5&humidity=10&precipitation=5&cloud_amount=10&air_quality=2')
         data = json.loads(response.text)
@@ -92,6 +92,36 @@ class TestManger(unittest.TestCase):
                   'Precipitation': '5 mm',
                   'Cloud amount': '10 %',
                   'Air quality': '2'}
+        self.assertEqual(tested, equals)'''
+    def test_get_simulated_pois_as_json(self):
+        # Define parameters
+        params = {
+            "air_temperature": 10,
+            "wind_speed": 5,
+            "humidity": 10,
+            "precipitation": 5,
+            "cloud_amount": 10,
+            "air_quality": 2,
+            "current_time": '16:00',
+            'sunrise': '6:00',
+            'sunset': '22:00',
+        }
+
+        # Make POST request and get response
+        response = self.client.post(
+            '/api/simulator', 
+            json=params,
+        )
+
+        data = json.loads(response.text)
+        tested = data[0]['weather']['Weather']
+        del tested['Score']
+        equals = {'Air temperature': '10 °C',
+                'Wind speed': '5 m/s',
+                'Humidity': '10 %',
+                'Precipitation': '5 mm',
+                'Cloud amount': '10 %',
+                'Air quality': 2}
         self.assertEqual(tested, equals)
 
     def test_get_pois_returns_list(self):

--- a/recommender-back/src/tests/apis/poi_test.py
+++ b/recommender-back/src/tests/apis/poi_test.py
@@ -43,19 +43,19 @@ class TestPointOfInterest(unittest.TestCase):
         sunset = datetime(2023, 6, 23, 18, 0)
         cur_time = datetime(2023, 6, 23, 20, 0)
 
-        expected_score = 0.81
+        expected_score = 0.75
         score = self.poi._indoor_score(temperature, wind_speed, humidity, precipitation, clouds, sunrise, sunset, cur_time)
         self.assertAlmostEqual(score, expected_score, places=6)
         
         temperature = 7
         
-        expected_score = 0.85
+        expected_score = 0.79
         score = self.poi._indoor_score(temperature, wind_speed, humidity, precipitation, clouds, sunrise, sunset, cur_time)
         self.assertAlmostEqual(score, expected_score, places=6)
         
         temperature = 45
         
-        expected_score = 0.91
+        expected_score = 0.85
         score = self.poi._indoor_score(temperature, wind_speed, humidity, precipitation, clouds, sunrise, sunset, cur_time)
         self.assertAlmostEqual(score, expected_score, places=6)
 
@@ -72,7 +72,7 @@ class TestPointOfInterest(unittest.TestCase):
             test_poi.weather = weather
             test_poi.sun = sun
 
-            expected_score = 0.79
+            expected_score = 0.73
 
             test_poi.calculate_score()
             score = test_poi.weather['20:00']['Score']

--- a/recommender-front/cypress/e2e/recommender.cy.js
+++ b/recommender-front/cypress/e2e/recommender.cy.js
@@ -90,3 +90,32 @@ describe('SimulatorPage', () => {
     cy.get('input[name="airTemperature"]').clear().type('20').should('have.value', '20');
   });
 });
+
+describe('TimePickerComponent', () => {
+  // visit the page or component where TimePickerComponent is rendered
+  beforeEach(() => {
+    cy.visit('http://localhost:3000/admin');
+  });
+
+  it('should select an hour correctly', () => {
+    cy.get('[data-testid="current-time-hour-selector"] div[role="button"]').first().click();
+    cy.get('li[data-value="10"]').click();
+    cy.get('[name="current-time-hour"]').should('have.value', '10');
+  });
+
+  it('should select a minute correctly', () => {
+    cy.get('[data-testid="current-time-minute-selector"] div[role="button"]').first().click();
+    cy.get('li[data-value="10"]').click();
+    cy.get('[name="current-time-minute"]').should('have.value', '10');
+  });
+
+  it('should display correct default sunrise', () => {
+    cy.get('[name="sunrise-hour"]').should('have.value', '06');
+    cy.get('[name="sunrise-minute"]').should('have.value', '00');
+  });
+
+  it('should display correct default sunset', () => {
+    cy.get('[name="sunset-hour"]').should('have.value', '22');
+    cy.get('[name="sunset-minute"]').should('have.value', '00');
+  });
+});

--- a/recommender-front/package-lock.json
+++ b/recommender-front/package-lock.json
@@ -12,7 +12,7 @@
         "@emotion/styled": "^11.11.0",
         "@fontsource/roboto": "^5.0.2",
         "@mui/icons-material": "^5.11.16",
-        "@mui/material": "^5.13.5",
+        "@mui/material": "^5.14.4",
         "@mui/system": "^5.13.5",
         "cypress": "^12.14.0",
         "eslint": "^8.41.0",
@@ -1773,15 +1773,20 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
-      "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
+      "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/@babel/template": {
       "version": "7.20.7",
@@ -3534,16 +3539,16 @@
       }
     },
     "node_modules/@mui/base": {
-      "version": "5.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.4.tgz",
-      "integrity": "sha512-ejhtqYJpjDgHGEljjMBQWZ22yEK0OzIXNa7toJmmXsP4TT3W7xVy8bTJ0TniPDf+JNjrsgfgiFTDGdlEhV1E+g==",
+      "version": "5.0.0-beta.10",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.10.tgz",
+      "integrity": "sha512-moTAhGwFfQffj7hsu61FnqcGqVcd53A1CrOhnskM9TF0Uh2rnLDMCuar4JRUWWpaJofAfQEbQBBFPadFQLI4PA==",
       "dependencies": {
-        "@babel/runtime": "^7.21.0",
+        "@babel/runtime": "^7.22.6",
         "@emotion/is-prop-valid": "^1.2.1",
         "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.13.1",
+        "@mui/utils": "^5.14.4",
         "@popperjs/core": "^2.11.8",
-        "clsx": "^1.2.1",
+        "clsx": "^2.0.0",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0"
       },
@@ -3571,9 +3576,9 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.13.4",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.13.4.tgz",
-      "integrity": "sha512-yFrMWcrlI0TqRN5jpb6Ma9iI7sGTHpytdzzL33oskFHNQ8UgrtPas33Y1K7sWAMwCrr1qbWDrOHLAQG4tAzuSw==",
+      "version": "5.14.4",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.4.tgz",
+      "integrity": "sha512-pW2XghSi3hpYKX57Wu0SCWMTSpzvXZmmucj3TcOJWaCiFt4xr05w2gcwBZi36dAp9uvd9//9N51qbblmnD+GPg==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui"
@@ -3605,18 +3610,18 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "5.13.5",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.13.5.tgz",
-      "integrity": "sha512-eMay+Ue1OYXOFMQA5Aau7qbAa/kWHLAyi0McsbPTWssCbGehqkF6CIdPsfVGw6tlO+xPee1hUitphHJNL3xpOQ==",
+      "version": "5.14.4",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.14.4.tgz",
+      "integrity": "sha512-2XUV3KyRC07BQPPzEgd+ss3x/ezXtHeKtOGCMCNmx3MauZojPYUpSwFkE0fYgYCD9dMQMVG4DY/VF38P0KShsg==",
       "dependencies": {
-        "@babel/runtime": "^7.21.0",
-        "@mui/base": "5.0.0-beta.4",
-        "@mui/core-downloads-tracker": "^5.13.4",
-        "@mui/system": "^5.13.5",
+        "@babel/runtime": "^7.22.6",
+        "@mui/base": "5.0.0-beta.10",
+        "@mui/core-downloads-tracker": "^5.14.4",
+        "@mui/system": "^5.14.4",
         "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.13.1",
+        "@mui/utils": "^5.14.4",
         "@types/react-transition-group": "^4.4.6",
-        "clsx": "^1.2.1",
+        "clsx": "^2.0.0",
         "csstype": "^3.1.2",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0",
@@ -3654,12 +3659,12 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/@mui/private-theming": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.13.1.tgz",
-      "integrity": "sha512-HW4npLUD9BAkVppOUZHeO1FOKUJWAwbpy0VQoGe3McUYTlck1HezGHQCfBQ5S/Nszi7EViqiimECVl9xi+/WjQ==",
+      "version": "5.14.4",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.14.4.tgz",
+      "integrity": "sha512-ISXsHDiQ3z1XA4IuKn+iXDWvDjcz/UcQBiFZqtdoIsEBt8CB7wgdQf3LwcwqO81dl5ofg/vNQBEnXuKfZHrnYA==",
       "dependencies": {
-        "@babel/runtime": "^7.21.0",
-        "@mui/utils": "^5.13.1",
+        "@babel/runtime": "^7.22.6",
+        "@mui/utils": "^5.14.4",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -3711,16 +3716,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.13.5",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.13.5.tgz",
-      "integrity": "sha512-n0gzUxoZ2ZHZgnExkh2Htvo9uW2oakofgPRQrDoa/GQOWyRD0NH9MDszBwOb6AAoXZb+OV5TE7I4LeZ/dzgHYA==",
+      "version": "5.14.4",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.4.tgz",
+      "integrity": "sha512-oPgfWS97QNfHcDBapdkZIs4G5i85BJt69Hp6wbXF6s7vi3Evcmhdk8AbCRW6n0sX4vTj8oe0mh0RIm1G2A1KDA==",
       "dependencies": {
-        "@babel/runtime": "^7.21.0",
-        "@mui/private-theming": "^5.13.1",
+        "@babel/runtime": "^7.22.6",
+        "@mui/private-theming": "^5.14.4",
         "@mui/styled-engine": "^5.13.2",
         "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.13.1",
-        "clsx": "^1.2.1",
+        "@mui/utils": "^5.14.4",
+        "clsx": "^2.0.0",
         "csstype": "^3.1.2",
         "prop-types": "^15.8.1"
       },
@@ -3763,13 +3768,13 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.13.1.tgz",
-      "integrity": "sha512-6lXdWwmlUbEU2jUI8blw38Kt+3ly7xkmV9ljzY4Q20WhsJMWiNry9CX8M+TaP/HbtuyR8XKsdMgQW7h7MM3n3A==",
+      "version": "5.14.4",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.4.tgz",
+      "integrity": "sha512-4ANV0txPD3x0IcTCSEHKDWnsutg1K3m6Vz5IckkbLXVYu17oOZCVUdOKsb/txUmaCd0v0PmSRe5PW+Mlvns5dQ==",
       "dependencies": {
-        "@babel/runtime": "^7.21.0",
+        "@babel/runtime": "^7.22.6",
         "@types/prop-types": "^15.7.5",
-        "@types/react-is": "^18.2.0",
+        "@types/react-is": "^18.2.1",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0"
       },
@@ -4875,9 +4880,9 @@
       }
     },
     "node_modules/@types/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-1vz2yObaQkLL7YFe/pme2cpvDsCwI1WXIfL+5eLz0MI9gFG24Re16RzUsI8t9XZn9ZWvgLNDrJBmrqXJO7GNQQ==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-18.2.1.tgz",
+      "integrity": "sha512-wyUkmaaSZEzFZivD8F2ftSyAfk6L+DfFliVj/mYdOXbVjRcS87fQJLTnhk6dRZPuJjI+9g6RZJO4PNCngUrmyw==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -6864,9 +6869,9 @@
       }
     },
     "node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
       "engines": {
         "node": ">=6"
       }
@@ -25222,11 +25227,18 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "@babel/runtime": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
-      "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
+      "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
       "requires": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+          "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+        }
       }
     },
     "@babel/template": {
@@ -26499,16 +26511,16 @@
       }
     },
     "@mui/base": {
-      "version": "5.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.4.tgz",
-      "integrity": "sha512-ejhtqYJpjDgHGEljjMBQWZ22yEK0OzIXNa7toJmmXsP4TT3W7xVy8bTJ0TniPDf+JNjrsgfgiFTDGdlEhV1E+g==",
+      "version": "5.0.0-beta.10",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.10.tgz",
+      "integrity": "sha512-moTAhGwFfQffj7hsu61FnqcGqVcd53A1CrOhnskM9TF0Uh2rnLDMCuar4JRUWWpaJofAfQEbQBBFPadFQLI4PA==",
       "requires": {
-        "@babel/runtime": "^7.21.0",
+        "@babel/runtime": "^7.22.6",
         "@emotion/is-prop-valid": "^1.2.1",
         "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.13.1",
+        "@mui/utils": "^5.14.4",
         "@popperjs/core": "^2.11.8",
-        "clsx": "^1.2.1",
+        "clsx": "^2.0.0",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0"
       },
@@ -26521,9 +26533,9 @@
       }
     },
     "@mui/core-downloads-tracker": {
-      "version": "5.13.4",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.13.4.tgz",
-      "integrity": "sha512-yFrMWcrlI0TqRN5jpb6Ma9iI7sGTHpytdzzL33oskFHNQ8UgrtPas33Y1K7sWAMwCrr1qbWDrOHLAQG4tAzuSw=="
+      "version": "5.14.4",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.4.tgz",
+      "integrity": "sha512-pW2XghSi3hpYKX57Wu0SCWMTSpzvXZmmucj3TcOJWaCiFt4xr05w2gcwBZi36dAp9uvd9//9N51qbblmnD+GPg=="
     },
     "@mui/icons-material": {
       "version": "5.11.16",
@@ -26534,18 +26546,18 @@
       }
     },
     "@mui/material": {
-      "version": "5.13.5",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.13.5.tgz",
-      "integrity": "sha512-eMay+Ue1OYXOFMQA5Aau7qbAa/kWHLAyi0McsbPTWssCbGehqkF6CIdPsfVGw6tlO+xPee1hUitphHJNL3xpOQ==",
+      "version": "5.14.4",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.14.4.tgz",
+      "integrity": "sha512-2XUV3KyRC07BQPPzEgd+ss3x/ezXtHeKtOGCMCNmx3MauZojPYUpSwFkE0fYgYCD9dMQMVG4DY/VF38P0KShsg==",
       "requires": {
-        "@babel/runtime": "^7.21.0",
-        "@mui/base": "5.0.0-beta.4",
-        "@mui/core-downloads-tracker": "^5.13.4",
-        "@mui/system": "^5.13.5",
+        "@babel/runtime": "^7.22.6",
+        "@mui/base": "5.0.0-beta.10",
+        "@mui/core-downloads-tracker": "^5.14.4",
+        "@mui/system": "^5.14.4",
         "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.13.1",
+        "@mui/utils": "^5.14.4",
         "@types/react-transition-group": "^4.4.6",
-        "clsx": "^1.2.1",
+        "clsx": "^2.0.0",
         "csstype": "^3.1.2",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0",
@@ -26560,12 +26572,12 @@
       }
     },
     "@mui/private-theming": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.13.1.tgz",
-      "integrity": "sha512-HW4npLUD9BAkVppOUZHeO1FOKUJWAwbpy0VQoGe3McUYTlck1HezGHQCfBQ5S/Nszi7EViqiimECVl9xi+/WjQ==",
+      "version": "5.14.4",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.14.4.tgz",
+      "integrity": "sha512-ISXsHDiQ3z1XA4IuKn+iXDWvDjcz/UcQBiFZqtdoIsEBt8CB7wgdQf3LwcwqO81dl5ofg/vNQBEnXuKfZHrnYA==",
       "requires": {
-        "@babel/runtime": "^7.21.0",
-        "@mui/utils": "^5.13.1",
+        "@babel/runtime": "^7.22.6",
+        "@mui/utils": "^5.14.4",
         "prop-types": "^15.8.1"
       }
     },
@@ -26581,16 +26593,16 @@
       }
     },
     "@mui/system": {
-      "version": "5.13.5",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.13.5.tgz",
-      "integrity": "sha512-n0gzUxoZ2ZHZgnExkh2Htvo9uW2oakofgPRQrDoa/GQOWyRD0NH9MDszBwOb6AAoXZb+OV5TE7I4LeZ/dzgHYA==",
+      "version": "5.14.4",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.4.tgz",
+      "integrity": "sha512-oPgfWS97QNfHcDBapdkZIs4G5i85BJt69Hp6wbXF6s7vi3Evcmhdk8AbCRW6n0sX4vTj8oe0mh0RIm1G2A1KDA==",
       "requires": {
-        "@babel/runtime": "^7.21.0",
-        "@mui/private-theming": "^5.13.1",
+        "@babel/runtime": "^7.22.6",
+        "@mui/private-theming": "^5.14.4",
         "@mui/styled-engine": "^5.13.2",
         "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.13.1",
-        "clsx": "^1.2.1",
+        "@mui/utils": "^5.14.4",
+        "clsx": "^2.0.0",
         "csstype": "^3.1.2",
         "prop-types": "^15.8.1"
       }
@@ -26602,13 +26614,13 @@
       "requires": {}
     },
     "@mui/utils": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.13.1.tgz",
-      "integrity": "sha512-6lXdWwmlUbEU2jUI8blw38Kt+3ly7xkmV9ljzY4Q20WhsJMWiNry9CX8M+TaP/HbtuyR8XKsdMgQW7h7MM3n3A==",
+      "version": "5.14.4",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.4.tgz",
+      "integrity": "sha512-4ANV0txPD3x0IcTCSEHKDWnsutg1K3m6Vz5IckkbLXVYu17oOZCVUdOKsb/txUmaCd0v0PmSRe5PW+Mlvns5dQ==",
       "requires": {
-        "@babel/runtime": "^7.21.0",
+        "@babel/runtime": "^7.22.6",
         "@types/prop-types": "^15.7.5",
-        "@types/react-is": "^18.2.0",
+        "@types/react-is": "^18.2.1",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0"
       },
@@ -27427,9 +27439,9 @@
       }
     },
     "@types/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-1vz2yObaQkLL7YFe/pme2cpvDsCwI1WXIfL+5eLz0MI9gFG24Re16RzUsI8t9XZn9ZWvgLNDrJBmrqXJO7GNQQ==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-18.2.1.tgz",
+      "integrity": "sha512-wyUkmaaSZEzFZivD8F2ftSyAfk6L+DfFliVj/mYdOXbVjRcS87fQJLTnhk6dRZPuJjI+9g6RZJO4PNCngUrmyw==",
       "requires": {
         "@types/react": "*"
       }
@@ -28890,9 +28902,9 @@
       "dev": true
     },
     "clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q=="
     },
     "co": {
       "version": "4.6.0",

--- a/recommender-front/package.json
+++ b/recommender-front/package.json
@@ -7,7 +7,7 @@
     "@emotion/styled": "^11.11.0",
     "@fontsource/roboto": "^5.0.2",
     "@mui/icons-material": "^5.11.16",
-    "@mui/material": "^5.13.5",
+    "@mui/material": "^5.14.4",
     "@mui/system": "^5.13.5",
     "cypress": "^12.14.0",
     "eslint": "^8.41.0",

--- a/recommender-front/src/assets/style.css
+++ b/recommender-front/src/assets/style.css
@@ -208,6 +208,8 @@ body {
   z-index: 1000;
   background-color: #ffffff;
   padding: 10px;
+  max-height: 70vh;
+  overflow-y: auto;
 }
 
 .fullscreen {
@@ -246,7 +248,7 @@ body {
   pointer-events: none;
 }
 
-@media (max-width: 600px) {
+@media screen and (max-width: 600px) {
   .header-container {
     min-height: 60px;
     flex-direction: column;

--- a/recommender-front/src/assets/style.css
+++ b/recommender-front/src/assets/style.css
@@ -235,6 +235,17 @@ body {
 }
 
 
+.night-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 999;
+  pointer-events: none;
+}
+
 @media (max-width: 600px) {
   .header-container {
     min-height: 60px;

--- a/recommender-front/src/components/simulator/SimulatorFormComponent.jsx
+++ b/recommender-front/src/components/simulator/SimulatorFormComponent.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Typography from '@mui/material/Typography';
 import CustomTextField from './CustomTextField';
+import TimePickerComponent from './TimePickerComponent';
 
 function SimulatorFormComponent({
   handleInputChange,
@@ -20,9 +21,9 @@ function SimulatorFormComponent({
     borderRadius: '5px',
     display: 'grid',
     gap: '5px',
-    width: '120px',
-    height: '70vh',
-    maxHeight: '7vh',
+    width: '140px',
+    height: '65vh',
+    maxHeight: '65vh',
     overFlowy: 'auto',
   };
 
@@ -78,25 +79,19 @@ function SimulatorFormComponent({
           helperText="1-5"
         />
         <Typography>Current Time</Typography>
-        <CustomTextField
-          name="currentTime"
-          placeholder="Current Time"
-          value={currentTime}
-          handleInputChange={handleTimeChange}
+        <TimePickerComponent
+          time={currentTime}
+          onTimeChange={handleTimeChange}
         />
         <Typography>Sunrise</Typography>
-        <CustomTextField
-          name="sunrise"
-          placeholder="Sunrise"
-          value={sunrise}
-          handleInputChange={handleSunriseChange}
+        <TimePickerComponent
+          time={sunrise}
+          onTimeChange={handleSunriseChange}
         />
         <Typography>Sunset</Typography>
-        <CustomTextField
-          name="sunset"
-          placeholder="Sunset"
-          value={sunset}
-          handleInputChange={handleSunsetChange}
+        <TimePickerComponent
+          time={sunset}
+          onTimeChange={handleSunsetChange}
         />
       </form>
     </div>

--- a/recommender-front/src/components/simulator/SimulatorFormComponent.jsx
+++ b/recommender-front/src/components/simulator/SimulatorFormComponent.jsx
@@ -82,16 +82,19 @@ function SimulatorFormComponent({
         <TimePickerComponent
           time={currentTime}
           onTimeChange={handleTimeChange}
+          namePrefix="current-time"
         />
         <Typography>Sunrise</Typography>
         <TimePickerComponent
           time={sunrise}
           onTimeChange={handleSunriseChange}
+          namePrefix="sunrise"
         />
         <Typography>Sunset</Typography>
         <TimePickerComponent
           time={sunset}
           onTimeChange={handleSunsetChange}
+          namePrefix="sunset"
         />
       </form>
     </div>

--- a/recommender-front/src/components/simulator/SimulatorFormComponent.jsx
+++ b/recommender-front/src/components/simulator/SimulatorFormComponent.jsx
@@ -21,6 +21,9 @@ function SimulatorFormComponent({
     display: 'grid',
     gap: '5px',
     width: '120px',
+    height: '70vh',
+    maxHeight: '7vh',
+    overFlowy: 'auto',
   };
 
   return (

--- a/recommender-front/src/components/simulator/SimulatorFormComponent.jsx
+++ b/recommender-front/src/components/simulator/SimulatorFormComponent.jsx
@@ -2,7 +2,16 @@ import React from 'react';
 import Typography from '@mui/material/Typography';
 import CustomTextField from './CustomTextField';
 
-function SimulatorFormComponent({ handleInputChange, simulatedWeatherData }) {
+function SimulatorFormComponent({
+  handleInputChange,
+  simulatedWeatherData,
+  handleTimeChange,
+  currentTime,
+  handleSunriseChange,
+  sunrise,
+  handleSunsetChange,
+  sunset,
+}) {
   const formStyle = {
     bottom: '10px',
     left: '10px',
@@ -64,6 +73,27 @@ function SimulatorFormComponent({ handleInputChange, simulatedWeatherData }) {
           value={simulatedWeatherData.airQuality}
           handleInputChange={handleInputChange}
           helperText="1-5"
+        />
+        <Typography>Current Time</Typography>
+        <CustomTextField
+          name="currentTime"
+          placeholder="Current Time"
+          value={currentTime}
+          handleInputChange={handleTimeChange}
+        />
+        <Typography>Sunrise</Typography>
+        <CustomTextField
+          name="sunrise"
+          placeholder="Sunrise"
+          value={sunrise}
+          handleInputChange={handleSunriseChange}
+        />
+        <Typography>Sunset</Typography>
+        <CustomTextField
+          name="sunset"
+          placeholder="Sunset"
+          value={sunset}
+          handleInputChange={handleSunsetChange}
         />
       </form>
     </div>

--- a/recommender-front/src/components/simulator/TimePickerComponent.jsx
+++ b/recommender-front/src/components/simulator/TimePickerComponent.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import Typography from '@mui/material/Typography';
+
+function TimePickerComponent({ time, onTimeChange }) {
+  const [hour, minute] = (time || '00:00').split(':');
+
+  const handleHourChange = (newHour) => {
+    onTimeChange(null, { hours: newHour, minutes: minute });
+  };
+
+  const handleMinuteChange = (newMinute) => {
+    onTimeChange(null, { hours: hour, minutes: newMinute });
+  };
+
+  return (
+    <div style={{ display: 'flex', gap: '5px' }}>
+      <Select
+        value={hour}
+        onChange={(e) => handleHourChange(e.target.value)}
+        name="hour"
+      >
+        {Array.from({ length: 24 }).map((_, index) => {
+          const hourValue = String(index).padStart(2, '0');
+          return (
+            <MenuItem key={hourValue} value={hourValue}>
+              {hourValue}
+            </MenuItem>
+          );
+        })}
+      </Select>
+      <Typography>:</Typography>
+      <Select
+        value={minute}
+        onChange={(e) => handleMinuteChange(e.target.value)}
+        name="minute"
+      >
+        {Array.from({ length: 60 }).map((_, index) => {
+          const minuteValue = String(index).padStart(2, '0');
+          return (
+            <MenuItem key={minuteValue} value={minuteValue}>
+              {minuteValue}
+            </MenuItem>
+          );
+        })}
+      </Select>
+    </div>
+  );
+}
+
+export default TimePickerComponent;

--- a/recommender-front/src/components/simulator/TimePickerComponent.jsx
+++ b/recommender-front/src/components/simulator/TimePickerComponent.jsx
@@ -3,7 +3,7 @@ import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';
 
-function TimePickerComponent({ time, onTimeChange }) {
+function TimePickerComponent({ time, onTimeChange, namePrefix }) {
   const [hour, minute] = (time || '00:00').split(':');
 
   const handleHourChange = (newHour) => {
@@ -19,7 +19,8 @@ function TimePickerComponent({ time, onTimeChange }) {
       <Select
         value={hour}
         onChange={(e) => handleHourChange(e.target.value)}
-        name="hour"
+        name={`${namePrefix}-hour`}
+        data-testid={`${namePrefix}-hour-selector`}
       >
         {Array.from({ length: 24 }).map((_, index) => {
           const hourValue = String(index).padStart(2, '0');
@@ -34,7 +35,8 @@ function TimePickerComponent({ time, onTimeChange }) {
       <Select
         value={minute}
         onChange={(e) => handleMinuteChange(e.target.value)}
-        name="minute"
+        name={`${namePrefix}-minute`}
+        data-testid={`${namePrefix}-minute-selector`}
       >
         {Array.from({ length: 60 }).map((_, index) => {
           const minuteValue = String(index).padStart(2, '0');

--- a/recommender-front/src/components/simulator/TimePickerComponent.test.jsx
+++ b/recommender-front/src/components/simulator/TimePickerComponent.test.jsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import TimePickerComponent from './TimePickerComponent';
+import '@testing-library/jest-dom/extend-expect';
+
+describe('TimePickerComponent', () => {
+  it('renders without crashing', () => {
+    render(<TimePickerComponent />);
+  });
+
+  it('displays the correct initial value', () => {
+    const { getByDisplayValue } = render(<TimePickerComponent time="06:30" />);
+    expect(getByDisplayValue('06')).toBeInTheDocument();
+    expect(getByDisplayValue('30')).toBeInTheDocument();
+  });
+});

--- a/recommender-front/src/pages/SimulatorPage.jsx
+++ b/recommender-front/src/pages/SimulatorPage.jsx
@@ -86,7 +86,8 @@ function SimulatorPage() {
   };
 
   const handleTimeChange = (event) => {
-    setCurrentTime(event.target.value);
+    const timeString = event.target.value;
+    setCurrentTime(timeString);
   };
 
   const handleSunriseChange = (event) => {

--- a/recommender-front/src/pages/SimulatorPage.jsx
+++ b/recommender-front/src/pages/SimulatorPage.jsx
@@ -4,6 +4,7 @@ import SimulatorFormComponent from '../components/simulator/SimulatorFormCompone
 import '../assets/style.css';
 import WeatherAlert from '../components/warning/WeatherAlert';
 import useDebounce from '../utils/DebounceUtil';
+import formatTimeValue from '../utils/TimeUtils';
 
 function SimulatorPage() {
   const [simulatedWeatherData, setSimulatedWeatherData] = useState({
@@ -14,8 +15,8 @@ function SimulatorPage() {
     cloudAmount: '0',
     airQuality: '2',
   });
-  const [currentTime, setCurrentTime] = useState(new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }));
-  const [sunrise, setSunrise] = useState('6:00');
+  const [currentTime, setCurrentTime] = useState(new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false }));
+  const [sunrise, setSunrise] = useState('06:00');
   const [sunset, setSunset] = useState('22:00');
   const [poiData, setPoiData] = useState([]);
   const [isNightTime, setIsNightTime] = useState(false);
@@ -72,7 +73,6 @@ function SimulatorPage() {
     } else {
       setIsNightTime(false);
     }
-    console.log(isNightTime);
   }, [currentTime, sunrise, sunset]);
 
   const handleInputChange = (event) => {
@@ -85,17 +85,19 @@ function SimulatorPage() {
     }
   };
 
-  const handleTimeChange = (event) => {
-    const timeString = event.target.value;
-    setCurrentTime(timeString);
+  const handleTimeChange = (event, value) => {
+    const formattedTime = formatTimeValue(value);
+    setCurrentTime(formattedTime);
   };
 
-  const handleSunriseChange = (event) => {
-    setSunrise(event.target.value);
+  const handleSunriseChange = (event, value) => {
+    const formattedSunrise = formatTimeValue(value);
+    setSunrise(formattedSunrise);
   };
 
-  const handleSunsetChange = (event) => {
-    setSunset(event.target.value);
+  const handleSunsetChange = (event, value) => {
+    const formattedSunset = formatTimeValue(value);
+    setSunset(formattedSunset);
   };
 
   return (

--- a/recommender-front/src/utils/DebounceUtil.jsx
+++ b/recommender-front/src/utils/DebounceUtil.jsx
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react';
+
+function useDebounce(value, delay) {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(
+    () => {
+      const handler = setTimeout(() => {
+        setDebouncedValue(value);
+      }, delay);
+
+      return () => {
+        clearTimeout(handler);
+      };
+    },
+    [value, delay],
+  );
+
+  return debouncedValue;
+}
+
+export default useDebounce;

--- a/recommender-front/src/utils/TimeUtils.jsx
+++ b/recommender-front/src/utils/TimeUtils.jsx
@@ -1,0 +1,15 @@
+const formatTimeValue = (timeInput) => {
+  if (typeof timeInput === 'string' && /^[0-9]{1,2}:[0-9]{2}$/.test(timeInput)) {
+    // If input is a valid string format like '6:00', directly return it
+    return timeInput;
+  }
+
+  if (timeInput && timeInput.hours !== undefined && timeInput.minutes !== undefined) {
+    const { hours, minutes } = timeInput;
+    return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+  }
+
+  return '00:00'; // Default value
+};
+
+export default formatTimeValue;

--- a/recommender-front/src/utils/TimeUtils.test.jsx
+++ b/recommender-front/src/utils/TimeUtils.test.jsx
@@ -1,0 +1,19 @@
+import formatTimeValue from './TimeUtils';
+
+describe('formatTimeValue', () => {
+  it('returns default value for undefined input', () => {
+    expect(formatTimeValue()).toBe('00:00');
+  });
+
+  it('returns the same value for valid string input', () => {
+    expect(formatTimeValue('6:00')).toBe('6:00');
+  });
+
+  it('formats object input correctly', () => {
+    expect(formatTimeValue({ hours: 6, minutes: 30 })).toBe('06:30');
+  });
+
+  it('returns default value for invalid object', () => {
+    expect(formatTimeValue({ hours: 6 })).toBe('00:00');
+  });
+});


### PR DESCRIPTION
Added .env to local docker-compose so MongoDB works when running docker compose up locally.

BACKEND:
Added current_time, sunrise and sunset as params to routes and manager.get_simulated_pois_as_json.
Added same params as optional params to scoring functions in poi.py so it works with simulator and main app.
Indoor scoring had a bug so scores were always .06 higher due to it considering that it's daytime even when not daytime. Had to fix tests to reflect this.
Added function to times.py to transform time strings to datetime objects so they can be compared more easily.
Switched /api/simulator route to use POST instead of GET.

FRONTEND:
Added nightoverlay to simulator (not yet to main app).
DebounceUtil is there limit backend requests when user is playing around with time params. Otherwise it would fire a request on every keystroke. So typing in 21:00 would first fire a post request with current time as 2, then as 21. The responses from first keystroke would get mixed up with second and confuse the scores.



