### PR TITLE
moved accessibility filtering to frontend

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,8 +9,6 @@ services:
    - ./recommender-back/.env
   environment:
    REQUEST_ORIGIN: http://localhost:3000
-  env_file:
-    - ./recommender-back/.env
   ports:
    - 5000:5000
  

--- a/recommender-back/Dockerfile
+++ b/recommender-back/Dockerfile
@@ -12,7 +12,7 @@ COPY pyproject.toml poetry.lock*  /app/
 
 RUN pip install poetry \
   && poetry config virtualenvs.create false \
-  && poetry install --no-dev --no-interaction --no-ansi
+  && poetry install --only main --no-interaction --no-ansi
 
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y \
 COPY install_eccodes.sh /app/
 RUN chmod +x /app/install_eccodes.sh && /app/install_eccodes.sh
 
-RUN poetry run pip install netCDF4
+RUN poetry run pip install netCDF4 cachetools scipy
 
 COPY . /app
 

--- a/recommender-back/src/apis/manager.py
+++ b/recommender-back/src/apis/manager.py
@@ -33,7 +33,7 @@ def get_simulated_pois_as_json(air_temperature, wind_speed, humidity,
         return {"message": "Forecast timed out", "status": 500, "error": str(error)}
 
 
-def get_pois_as_json(accessibility=False, category="All"):
+def get_pois_as_json(category="All"):
     """
     Retrieves points of interest (POIs) from MongoDB and enriches them with current weather data.
 
@@ -64,8 +64,6 @@ def get_pois_as_json(accessibility=False, category="All"):
             poi: PointOfInterest = current.find_nearest_stations_weather_data(poi)
             poi = find_nearest_coordinate_forecast_data(poi, forecast_data)
             poi.calculate_score()
-            if accessibility in poi.not_accessible_for:
-                continue
             updated_data.append(poi.get_json())
         return json.dumps(updated_data)
     except KeyError as error:

--- a/recommender-back/src/apis/manager.py
+++ b/recommender-back/src/apis/manager.py
@@ -51,12 +51,12 @@ def get_pois_as_json(category="All"):
         response_fore = requests.get(url_fore, timeout=1200)
         response_fore.raise_for_status()
         forecast_data = response_fore.json()
-        url_aqi = os.environ.get("REACT_APP_BACKEND_URL") + "/api/aqi/"
-        response_aqi = requests.get(url_aqi, timeout=1200)
-        response_aqi.raise_for_status()
-        aqi_data = response_aqi.json()
-        aqi_data = _replace_datetime_in_aqi_data(forecast_data, aqi_data)
-        forecast_data = _add_aqi_to_forecast(forecast_data, aqi_data)
+        #url_aqi = os.environ.get("REACT_APP_BACKEND_URL") + "/api/aqi/"
+        #response_aqi = requests.get(url_aqi, timeout=1200)
+        #response_aqi.raise_for_status()
+        #aqi_data = response_aqi.json()
+        #aqi_data = _replace_datetime_in_aqi_data(forecast_data, aqi_data)
+        #forecast_data = _add_aqi_to_forecast(forecast_data, aqi_data)
         updated_data = []
         for poi in pois:
             if category not in poi.categories:

--- a/recommender-back/src/apis/manager.py
+++ b/recommender-back/src/apis/manager.py
@@ -33,7 +33,7 @@ def get_simulated_pois_as_json(air_temperature, wind_speed, humidity,
         return {"message": "Forecast timed out", "status": 500, "error": str(error)}
 
 
-def get_pois_as_json(category="All"):
+def get_pois_as_json(accessibility=False, category="All"):
     """
     Retrieves points of interest (POIs) from MongoDB and enriches them with current weather data.
 
@@ -51,12 +51,12 @@ def get_pois_as_json(category="All"):
         response_fore = requests.get(url_fore, timeout=1200)
         response_fore.raise_for_status()
         forecast_data = response_fore.json()
-        #url_aqi = os.environ.get("REACT_APP_BACKEND_URL") + "/api/aqi/"
-        #response_aqi = requests.get(url_aqi, timeout=1200)
-        #response_aqi.raise_for_status()
-        #aqi_data = response_aqi.json()
-        #aqi_data = _replace_datetime_in_aqi_data(forecast_data, aqi_data)
-        #forecast_data = _add_aqi_to_forecast(forecast_data, aqi_data)
+        url_aqi = os.environ.get("REACT_APP_BACKEND_URL") + "/api/aqi/"
+        response_aqi = requests.get(url_aqi, timeout=1200)
+        response_aqi.raise_for_status()
+        aqi_data = response_aqi.json()
+        aqi_data = _replace_datetime_in_aqi_data(forecast_data, aqi_data)
+        forecast_data = _add_aqi_to_forecast(forecast_data, aqi_data)
         updated_data = []
         for poi in pois:
             if category not in poi.categories:

--- a/recommender-back/src/apis/poi.py
+++ b/recommender-back/src/apis/poi.py
@@ -132,4 +132,5 @@ class PointOfInterest:
         '''
         return {'name': self.name, 'weather': self.weather,
                 'latitude': self.latitude, 'longitude': self.longitude,
-                'category': self.categories[-1], 'catetype': self.categorytype}
+                'category': self.categories[-1], 'catetype': self.categorytype,
+                'not_accessible_for': self.not_accessible_for}

--- a/recommender-back/src/routes.py
+++ b/recommender-back/src/routes.py
@@ -67,15 +67,7 @@ def get_poi_data():
         Poi data if errors have not occurred.
     """
     return manager.get_pois_as_json()
-
-@app.route("/api/poi/<accessibility>", methods=["GET"])
-def get_poi_acessible_poi_data(accessibility):
-    """
-    Handler for the '/api/poi' endpoint.
-    Returns:
-        POI-data if errors have not occurred.
-    """
-    return manager.get_pois_as_json(accessibility)
+    
 
 
 @app.route("/api/simulator", methods=["POST"])

--- a/recommender-back/src/routes.py
+++ b/recommender-back/src/routes.py
@@ -69,17 +69,6 @@ def get_poi_data():
     return manager.get_pois_as_json()
 
 
-@app.route("/api/poi/<accessibility>", methods=["GET"])
-def get_poi_acessible_poi_data(accessibility):
-    """
-    Handler for the '/api/poi' endpoint.
-
-    Returns:
-        POI-data if errors have not occurred.
-    """
-    return manager.get_pois_as_json(accessibility)
-
-
 @app.route("/api/simulator", methods=["POST"])
 def get_simulated_poi_data():
     """

--- a/recommender-back/src/routes.py
+++ b/recommender-back/src/routes.py
@@ -68,6 +68,15 @@ def get_poi_data():
     """
     return manager.get_pois_as_json()
 
+@app.route("/api/poi/<accessibility>", methods=["GET"])
+def get_poi_acessible_poi_data(accessibility):
+    """
+    Handler for the '/api/poi' endpoint.
+    Returns:
+        POI-data if errors have not occurred.
+    """
+    return manager.get_pois_as_json(accessibility)
+
 
 @app.route("/api/simulator", methods=["POST"])
 def get_simulated_poi_data():

--- a/recommender-back/src/tests/apis/poi_test.py
+++ b/recommender-back/src/tests/apis/poi_test.py
@@ -105,11 +105,29 @@ class TestPointOfInterest(unittest.TestCase):
 
         sun = ('06:00','18:00')
         categories = ['Open air pools and beaches']
+        not_accessible_for = ['wheelchair']
 
         test_poi = PointOfInterest(name= 'Test POI', latitude=21, longitude=61, categories=categories)
         test_poi.weather = weather
         test_poi.sun = sun
-        expected_json = {"name": 'Test POI', "weather": {"12:00": {"Wind speed": "5.0 m/s", "Precipitation": "20 mm", "Cloud amount": "0.6 %", "Air temperature": "23.0 *C", "Humidity": "0.5 %"}}, "latitude": 21, "longitude": 61, "category": "Open air pools and beaches", "catetype": None}
+        test_poi.not_accessible_for = not_accessible_for
+        expected_json = {
+            "name": 'Test POI',
+            "weather": {
+                "12:00": {
+                    "Wind speed": "5.0 m/s",
+                    "Precipitation": "20 mm",
+                    "Cloud amount": "0.6 %",
+                    "Air temperature": "23.0 *C",
+                    "Humidity": "0.5 %"
+                    }
+                },
+            "latitude": 21,
+            "longitude": 61,
+            "category": "Open air pools and beaches",
+            "catetype": None,
+            "not_accessible_for": not_accessible_for
+        }
 
         test_json = test_poi.get_json()
         

--- a/recommender-front/cypress/e2e/recommender.cy.js
+++ b/recommender-front/cypress/e2e/recommender.cy.js
@@ -175,17 +175,14 @@ describe('PreferenceSelector component', () => {
 });
 
 describe('User location and routing feature', () => {
-
   const latitude = 60.169520;
   const longitude = 24.935450;
-  
+
   beforeEach(() => {
     cy.intercept('GET', 'http://localhost:5000/api/poi/', mockPOIS);
     cy.intercept('GET', 'http://localhost:5000/api/warning', JSON.stringify(false));
     cy.window().then((win) => {
-      cy.stub(win.navigator.geolocation, 'getCurrentPosition', (callback) => {
-        return callback({ coords: { latitude, longitude } });
-      });
+      cy.stub(win.navigator.geolocation, 'getCurrentPosition', (callback) => callback({ coords: { latitude, longitude } }));
     });
     cy.visit('http://localhost:3000');
   });

--- a/recommender-front/cypress/e2e/recommender.cy.js
+++ b/recommender-front/cypress/e2e/recommender.cy.js
@@ -1,9 +1,9 @@
-import mockPOIS from '../mockData';
+import mockPOIs from '../mockData';
 import mockROUTE from '../mockRoute';
 
 describe('Map and POI features', () => {
   beforeEach(() => {
-    cy.intercept('GET', 'http://localhost:5000/api/poi/', mockPOIS);
+    cy.intercept('GET', 'http://localhost:5000/api/poi/', mockPOIs);
     cy.intercept('GET', 'http://localhost:5000/api/warning', JSON.stringify(false));
     cy.visit('');
   });
@@ -14,19 +14,19 @@ describe('Map and POI features', () => {
 
   it('should display all POI markers on initial load', () => {
     cy.get('.leaflet-marker-icon', { timeout: 10000 })
-      .should('have.length', mockPOIS.length);
+      .should('have.length', mockPOIs.length);
   });
 
   it('should display clustered markers correctly', () => {
     // Create a copy of the mock POI data
-    const clusteredMockPOIs = JSON.parse(JSON.stringify(mockPOIS));
+    const clusteredMockPOIs = JSON.parse(JSON.stringify(mockPOIs));
     // Move one POI closer to another so they are clustered
     clusteredMockPOIs[0].latitude = 60.190;
     cy.intercept('GET', 'http://localhost:5000/api/poi/', clusteredMockPOIs);
     cy.visit('');
 
     cy.get('.leaflet-marker-icon', { timeout: 10000 })
-      .should('have.length', mockPOIS.length - 1);
+      .should('have.length', mockPOIs.length - 1);
   });
 
   it('should update the popup content when the time slider is moved', () => {
@@ -50,7 +50,7 @@ describe('Map and POI features', () => {
   });
 
   it('should update amount of markers when accessibility is selected', () => {
-    const filteredMockPOIs = mockPOIS.filter((poi) => !poi.not_accessible_for.includes('wheelchair'));
+    const filteredMockPOIs = mockPOIs.filter((poi) => !poi.not_accessible_for.includes('wheelchair'));
 
     cy.get('.MuiSelect-select').click();
     cy.get('[data-value="wheelchair"]').click();
@@ -122,7 +122,7 @@ describe('TimePickerComponent', () => {
 
 describe('PreferenceSelector component', () => {
   beforeEach(() => {
-    cy.intercept('GET', 'http://localhost:5000/api/poi/', mockPOIS);
+    cy.intercept('GET', 'http://localhost:5000/api/poi/', mockPOIs);
     cy.intercept('GET', 'http://localhost:5000/api/warning', JSON.stringify(false));
     cy.visit('');
   });
@@ -138,8 +138,9 @@ describe('PreferenceSelector component', () => {
   });
 
   it('should show only Sport halls markers when the "Sport halls" category is selected', () => {
-    const sportHallsMockData = mockPOIS.filter((poi) => poi.category === 'Sport halls');
+    const sportHallsMockData = mockPOIs.filter((poi) => poi.category === 'Sport halls');
 
+    cy.get('[data-testid="menu-button"]').click();
     cy.get('input[name="Sport hallsCheckbox"]').check();
     cy.get('.leaflet-marker-icon', { timeout: 10000 })
       .should('have.length', sportHallsMockData.length);
@@ -158,14 +159,17 @@ describe('PreferenceSelector component', () => {
     cy.get('input[name="Sport hallsCheckbox"]').check();
     cy.get('input[name="allCheckbox"]').check();
     cy.get('.leaflet-marker-icon', { timeout: 10000 })
-      .should('have.length', mockPOIS.length);
+      .should('have.length', mockPOIs.length);
   });
 
   it('should show only Sport halls and wheelchair accessible markers when both filters are selected', () => {
-    const filteredMockPOIs = mockPOIS.filter((poi) => !poi.not_accessible_for.includes('wheelchair')
+    const filteredMockPOIs = mockPOIs.filter((poi) => !poi.not_accessible_for.includes('wheelchair')
       && poi.category === 'sport halls');
 
+    cy.get('[data-testid="menu-button"]').click();
     cy.get('input[name="Sport hallsCheckbox"]').check();
+    cy.get('button[aria-label="Close"]').click();
+
     cy.get('.MuiSelect-select').click();
     cy.get('[data-value="wheelchair"]').click();
 
@@ -179,12 +183,12 @@ describe('User location and routing feature', () => {
   const longitude = 24.935450;
 
   beforeEach(() => {
-    cy.intercept('GET', 'http://localhost:5000/api/poi/', mockPOIS);
+    cy.intercept('GET', 'http://localhost:5000/api/poi/', mockPOIs);
     cy.intercept('GET', 'http://localhost:5000/api/warning', JSON.stringify(false));
     cy.window().then((win) => {
       cy.stub(win.navigator.geolocation, 'getCurrentPosition', (callback) => callback({ coords: { latitude, longitude } }));
     });
-    cy.visit('http://localhost:3000');
+    cy.visit('');
   });
 
   it('should locate the user, open a POI and set a destination, draw the polyline', () => {

--- a/recommender-front/cypress/e2e/recommender.cy.js
+++ b/recommender-front/cypress/e2e/recommender.cy.js
@@ -22,7 +22,7 @@ describe('Map and POI features', () => {
     const clusteredMockPOIs = JSON.parse(JSON.stringify(mockPOIs));
     // Move one POI closer to another so they are clustered
     clusteredMockPOIs[0].latitude = 60.190;
-    cy.intercept('GET', 'http://localhost:5000/api/poi/', clusteredMockPOIs);
+    cy.intercept('GET', 'http://localhost:5000/api/poi', clusteredMockPOIs);
     cy.visit('');
 
     cy.get('.leaflet-marker-icon', { timeout: 10000 })
@@ -122,7 +122,7 @@ describe('TimePickerComponent', () => {
 
 describe('PreferenceSelector component', () => {
   beforeEach(() => {
-    cy.intercept('GET', 'http://localhost:5000/api/poi/', mockPOIs);
+    cy.intercept('GET', 'http://localhost:5000/api/poi', mockPOIs);
     cy.intercept('GET', 'http://localhost:5000/api/warning', JSON.stringify(false));
     cy.visit('');
   });
@@ -183,7 +183,7 @@ describe('User location and routing feature', () => {
   const longitude = 24.935450;
 
   beforeEach(() => {
-    cy.intercept('GET', 'http://localhost:5000/api/poi/', mockPOIs);
+    cy.intercept('GET', 'http://localhost:5000/api/poi', mockPOIs);
     cy.intercept('GET', 'http://localhost:5000/api/warning', JSON.stringify(false));
     cy.window().then((win) => {
       cy.stub(win.navigator.geolocation, 'getCurrentPosition', (callback) => callback({ coords: { latitude, longitude } }));

--- a/recommender-front/cypress/e2e/recommender.cy.js
+++ b/recommender-front/cypress/e2e/recommender.cy.js
@@ -139,7 +139,7 @@ describe('PreferenceSelector component', () => {
 
   it('should show only Sport halls markers when the "Sport halls" category is selected', () => {
     const sportHallsMockData = mockPOIS.filter((poi) => poi.category === 'Sport halls');
-    cy.get('[data-testid="menu-button"]').click();
+
     cy.get('input[name="Sport hallsCheckbox"]').check();
     cy.get('.leaflet-marker-icon', { timeout: 10000 })
       .should('have.length', sportHallsMockData.length);

--- a/recommender-front/cypress/e2e/recommender.cy.js
+++ b/recommender-front/cypress/e2e/recommender.cy.js
@@ -3,7 +3,7 @@ import mockROUTE from '../mockRoute';
 
 describe('Map and POI features', () => {
   beforeEach(() => {
-    cy.intercept('GET', 'http://localhost:5000/api/poi/', mockPOIs);
+    cy.intercept('GET', 'http://localhost:5000/api/poi', mockPOIs);
     cy.intercept('GET', 'http://localhost:5000/api/warning', JSON.stringify(false));
     cy.visit('');
   });

--- a/recommender-front/cypress/e2e/recommender.cy.js
+++ b/recommender-front/cypress/e2e/recommender.cy.js
@@ -162,7 +162,7 @@ describe('PreferenceSelector component', () => {
   });
 
   it('should show only Sport halls and wheelchair accessible markers when both filters are selected', () => {
-    const filteredMockPOIs = mockPOIs.filter((poi) => !poi.not_accessible_for.includes('wheelchair')
+    const filteredMockPOIs = mockPOIS.filter((poi) => !poi.not_accessible_for.includes('wheelchair')
       && poi.category === 'sport halls');
 
     cy.get('input[name="Sport hallsCheckbox"]').check();

--- a/recommender-front/cypress/e2e/recommender.cy.js
+++ b/recommender-front/cypress/e2e/recommender.cy.js
@@ -1,3 +1,4 @@
+import mockPOIs from '../mockData';
 import mockPOIS from '../mockData';
 import mockROUTE from '../mockRoute';
 
@@ -50,12 +51,12 @@ describe('Map and POI features', () => {
   });
 
   it('should update amount of markers when accessibility is selected', () => {
-    const wheelChairMockData = mockPOIS.slice(-1);
-    cy.intercept('GET', 'http://localhost:5000/api/poi/wheelchair', wheelChairMockData);
+    const filteredMockPOIs = mockPOIS.filter((poi) => !poi.not_accessible_for.includes('wheelchair'));
+
     cy.get('.MuiSelect-select').click();
     cy.get('[data-value="wheelchair"]').click();
     cy.get('.leaflet-marker-icon', { timeout: 10000 })
-      .should('have.length', wheelChairMockData.length);
+      .should('have.length', filteredMockPOIs.length);
   });
 
   it('should show the weather alert when /api/warning returns true', () => {
@@ -159,6 +160,18 @@ describe('PreferenceSelector component', () => {
     cy.get('input[name="allCheckbox"]').check();
     cy.get('.leaflet-marker-icon', { timeout: 10000 })
       .should('have.length', mockPOIS.length);
+  });
+
+  it('should show only Sport halls and wheelchair accessible markers when both filters are selected', () => {
+    const filteredMockPOIs = mockPOIs.filter((poi) => !poi.not_accessible_for.includes('wheelchair')
+      && poi.category === 'sport halls');
+
+    cy.get('input[name="Sport hallsCheckbox"]').check();
+    cy.get('.MuiSelect-select').click();
+    cy.get('[data-value="wheelchair"]').click();
+
+    cy.get('.leaflet-marker-icon', { timeout: 10000 })
+      .should('have.length', filteredMockPOIs.length);
   });
 });
 

--- a/recommender-front/cypress/e2e/recommender.cy.js
+++ b/recommender-front/cypress/e2e/recommender.cy.js
@@ -1,4 +1,3 @@
-import mockPOIs from '../mockData';
 import mockPOIS from '../mockData';
 import mockROUTE from '../mockRoute';
 

--- a/recommender-front/cypress/mockData.js
+++ b/recommender-front/cypress/mockData.js
@@ -27,6 +27,7 @@ const mockPOIs = [
       },
     },
     category: 'Sport halls',
+    not_accessible_for: ['wheelchair'],
   },
   {
     name: 'Mock POI 2',
@@ -56,6 +57,37 @@ const mockPOIs = [
       },
     },
     category: 'Open air pools and beaches',
+    not_accessible_for: [],
+  },
+  {
+    name: 'Mock POI 3',
+    latitude: 60.180,
+    longitude: 24.876,
+    weather: {
+      Current: {
+        'Air temperature': '20.0 °C',
+        Wind: '5.0 m/s',
+        'Air pressure': '1019 mbar',
+        Humidity: '45.0 %',
+        Score: 1.0,
+      },
+      '01:00': {
+        'Air temperature': '-5.5 °C',
+        Wind: '3.4 m/s',
+        'Air pressure': '1018 mbar',
+        Humidity: '43.3 %',
+        Score: 0.0,
+      },
+      '19:00': {
+        'Air temperature': '20.7 °C',
+        Wind: '4.7 m/s',
+        'Air pressure': '1019 mbar',
+        Humidity: '44.7 %',
+        Score: 0.3,
+      },
+    },
+    category: 'Fitness training parks',
+    not_accessible_for: [],
   },
 ];
 

--- a/recommender-front/cypress/mockData.js
+++ b/recommender-front/cypress/mockData.js
@@ -59,36 +59,6 @@ const mockPOIs = [
     category: 'Open air pools and beaches',
     not_accessible_for: [],
   },
-  {
-    name: 'Mock POI 3',
-    latitude: 60.180,
-    longitude: 24.876,
-    weather: {
-      Current: {
-        'Air temperature': '20.0 °C',
-        Wind: '5.0 m/s',
-        'Air pressure': '1019 mbar',
-        Humidity: '45.0 %',
-        Score: 1.0,
-      },
-      '01:00': {
-        'Air temperature': '-5.5 °C',
-        Wind: '3.4 m/s',
-        'Air pressure': '1018 mbar',
-        Humidity: '43.3 %',
-        Score: 0.0,
-      },
-      '19:00': {
-        'Air temperature': '20.7 °C',
-        Wind: '4.7 m/s',
-        'Air pressure': '1019 mbar',
-        Humidity: '44.7 %',
-        Score: 0.3,
-      },
-    },
-    category: 'Fitness training parks',
-    not_accessible_for: [],
-  },
 ];
 
 export default mockPOIs;

--- a/recommender-front/cypress/mockData.js
+++ b/recommender-front/cypress/mockData.js
@@ -59,6 +59,36 @@ const mockPOIs = [
     category: 'Open air pools and beaches',
     not_accessible_for: [],
   },
+  {
+    name: 'Mock POI 3',
+    latitude: 60.180,
+    longitude: 24.876,
+    weather: {
+      Current: {
+        'Air temperature': '20.0 °C',
+        Wind: '5.0 m/s',
+        'Air pressure': '1019 mbar',
+        Humidity: '45.0 %',
+        Score: 1.0,
+      },
+      '01:00': {
+        'Air temperature': '-5.5 °C',
+        Wind: '3.4 m/s',
+        'Air pressure': '1018 mbar',
+        Humidity: '43.3 %',
+        Score: 0.0,
+      },
+      '19:00': {
+        'Air temperature': '20.7 °C',
+        Wind: '4.7 m/s',
+        'Air pressure': '1019 mbar',
+        Humidity: '44.7 %',
+        Score: 0.3,
+      },
+    },
+    category: 'Fitness training parks',
+    not_accessible_for: [],
+  },
 ];
 
 export default mockPOIs;


### PR DESCRIPTION
closes #282 
fixes #281 
Added not_accessible_for data to poi.get_json() which allows for filtering to happen instantly in the frontend.
No need for lenghty api calls.
Some tests to check that category and accessibility filters work together.