### PR TITLE
Move mapping function to pathcomponent

### DIFF
--- a/recommender-front/cypress/e2e/recommender.cy.js
+++ b/recommender-front/cypress/e2e/recommender.cy.js
@@ -179,7 +179,7 @@ describe('User location and routing feature', () => {
   });
 
   it('should locate the user, open a POI and set a destination, draw the polyline', () => {
-    cy.get('[data-testid="locate-button"]').should('be.visible');
+    cy.get('[data-testid="locate-button"]').should('be.visible').click();
     cy.get('.leaflet-marker-icon').eq(1).click();
     cy.get('.leaflet-popup-content');
     cy.intercept('GET', '**/path?start=*&end=*', { body: mockROUTE }).as('getRoute');

--- a/recommender-front/src/components/map/MapComponent.jsx
+++ b/recommender-front/src/components/map/MapComponent.jsx
@@ -54,7 +54,7 @@ function MapComponent({
           handleSetDestination={handleSetDestination}
         />
         {routeCoordinates && (
-          <Polyline data-testid="map-polyline" positions={routeCoordinates.map((coord) => [coord[1], coord[0]])} />
+          <Polyline data-testid="map-polyline" positions={routeCoordinates} />
         )}
       </MapContainer>
     </div>

--- a/recommender-front/src/utils/PathComponent.jsx
+++ b/recommender-front/src/utils/PathComponent.jsx
@@ -10,7 +10,8 @@ function PathUtil({ origin, destination, setRouteCoordinates }) {
           end: destination.join(','),
         },
       });
-      setRouteCoordinates(response.data);
+      const coords = response.data.map((coord) => [coord[1], coord[0]]);
+      await setRouteCoordinates(coords);
       console.log('Success!');
     } catch (error) {
       console.error('Error sending coordinates:', error);

--- a/recommender-front/src/utils/PathComponent.test.jsx
+++ b/recommender-front/src/utils/PathComponent.test.jsx
@@ -11,8 +11,9 @@ describe('PathUtil', () => {
     const mockSetRouteCoordinates = jest.fn();
     const origin = [60.2049, 24.9649];
     const destination = [60.35, 25.355];
+    const mockData = [[60.2049, 24.9649],[60.35, 25.355]]
 
-    axios.get.mockResolvedValue({ data: 'mockData' });
+    axios.get.mockResolvedValue({ data: mockData });
 
     render(
       <PathUtil

--- a/recommender-front/src/utils/PathComponent.test.jsx
+++ b/recommender-front/src/utils/PathComponent.test.jsx
@@ -11,7 +11,7 @@ describe('PathUtil', () => {
     const mockSetRouteCoordinates = jest.fn();
     const origin = [60.2049, 24.9649];
     const destination = [60.35, 25.355];
-    const mockData = [[60.2049, 24.9649],[60.35, 25.355]]
+    const mockData = [[60.2049, 24.9649], [60.35, 25.355]];
 
     axios.get.mockResolvedValue({ data: mockData });
 


### PR DESCRIPTION
Maybe the problem was the conditional rendering with map function (I have no idea). Moved the function to pathing component so now the route coordinates are in correct form when passed to mapcomponent. Also the broken cypress test now works.