### PR TITLE
fixed bug in simulator

### DIFF
--- a/recommender-back/src/apis/poi.py
+++ b/recommender-back/src/apis/poi.py
@@ -25,13 +25,19 @@ class PointOfInterest:
         }
 
     def _extract_weather_data(self, data):
+        def extract_float(value, multiplier=1.0):
+            extracted_value = value.split(' ')[0]
+            if extracted_value == "-":
+                return 0.0
+            return float(extracted_value) * multiplier
+
         return {
-            'wind_speed': float(data.get('Wind speed').split(' ')[0]),
-            'precipitation': float(data.get('Precipitation').split(' ')[0]),
-            'clouds': float(data.get('Cloud amount').split(' ')[0]) * 0.01,
-            'temperature': float(data.get('Air temperature').split(' ')[0]),
-            'humidity': float(data.get('Humidity').split(' ')[0]) * 0.01,
-            'air_quality': float(data.get('Air quality').split(' ')[0]),
+            'wind_speed': extract_float(data.get('Wind speed')),
+            'precipitation': extract_float(data.get('Precipitation')),
+            'clouds': extract_float(data.get('Cloud amount'), 0.01),
+            'temperature': extract_float(data.get('Air temperature')),
+            'humidity': extract_float(data.get('Humidity'), 0.01),
+            'air_quality': extract_float(data.get('Air quality')),
         }
 
     def calculate_score(self, cur_time=None, sunrise=None, sunset=None):

--- a/recommender-back/src/tests/apis/poi_test.py
+++ b/recommender-back/src/tests/apis/poi_test.py
@@ -80,6 +80,30 @@ class TestPointOfInterest(unittest.TestCase):
         
         self.assertEqual(test_json, expected_json)
 
+
+    def test_extract_weather_data_with_dash(self):
+        test_data = {
+            'Wind speed': '5.0 m/s',
+            'Precipitation': '20 mm',
+            'Cloud amount': '0.6 %',
+            'Air temperature': '-',
+            'Humidity': '0.5 %',
+            'Air quality': '1.0 AQI'
+        }
+
+        expected_data = {
+            'wind_speed': 5.0,
+            'precipitation': 20.0,
+            'clouds': 0.006,
+            'temperature': 0.0,
+            'humidity': 0.005,
+            'air_quality': 1.0
+        }
+
+        extracted_data = self.poi._extract_weather_data(test_data)
+
+        self.assertEqual(extracted_data, expected_data)
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/recommender-front/cypress/e2e/recommender.cy.js
+++ b/recommender-front/cypress/e2e/recommender.cy.js
@@ -90,6 +90,10 @@ describe('SimulatorPage', () => {
   it('should allow input change in the SimulatorFormComponent', () => {
     cy.get('input[name="airTemperature"]').clear().type('20').should('have.value', '20');
   });
+
+  it('should not throw when temperature input is dash', () => {
+    cy.get('input[name="airTemperature"]').clear().type('-').should('have.value', '-');
+  });
 });
 
 describe('TimePickerComponent', () => {


### PR DESCRIPTION
Fixed bug where typing "-" in simulator temp field would throw.
Hardened backend to default to 0.0 if just - is given as input.
Wrote test case for backend and cypress.